### PR TITLE
Add WebAuthn passkey support to Web UI (registration & login)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -94,6 +94,24 @@ ACTIVE_MESHTASTIC_CHANNEL_INDEX = 0
 
 ## Advanced Configuration
 
+### Web UI Passkey (WebAuthn)
+
+Password login remains the default, but you can register and use passkeys as a safer fallback-resistant second method.
+
+Environment variables for WebAuthn in Web UI:
+
+```bash
+WEB_UI_WEBAUTHN_RP_ID=localhost
+WEB_UI_WEBAUTHN_RP_NAME="Meshtastic AI Bridge"
+WEB_UI_WEBAUTHN_ORIGIN=http://localhost:8080
+```
+
+Notes:
+- WebAuthn requires a secure context (`https://`) or `localhost`.
+- In LAN deployments, set `WEB_UI_WEBAUTHN_ORIGIN` to the exact browser origin (scheme + host + port).
+- Registered passkeys are stored in `data/webauthn_credentials.json`.
+- Username/password login is still supported for compatibility and recovery.
+
 ### 1. AI Persona Customization
 
 The AI persona defines how the AI behaves and responds:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ aiohttp>=3.9.0  # For async HTTP requests
 # Web UI
 flask>=3.0.0
 werkzeug>=3.0.0
+webauthn>=2.1.0
 
 # Matrix bridge (bidirectional mesh<->Matrix)
 matrix-nio[e2e]>=0.20.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -1158,6 +1158,7 @@
       </div>
     </div>
     <button onclick="toggleAbout()" title="About" style="background:none;border:1px solid var(--border-s);color:var(--muted);font-family:var(--font-mono);font-size:.7em;padding:3px 9px;cursor:pointer;border-radius:4px;">ℹ</button>
+    <button onclick="registerPasskey()" title="Register passkey" style="background:none;border:1px solid var(--border-s);color:var(--muted);font-family:var(--font-mono);font-size:.7em;padding:3px 9px;cursor:pointer;border-radius:4px;">passkey</button>
     <a href="/logout">logout</a>
   </div>
 </div>
@@ -5519,6 +5520,23 @@ async function fetchMyDeviceInfo() {
   setInterval(fetchChannels,    30000);
   setInterval(fetchTraceroutes, 10000);
 })();
+</script>
+<script src="https://unpkg.com/@simplewebauthn/browser/dist/bundle/index.umd.min.js"></script>
+<script>
+async function registerPasskey(){
+  try{
+    const begin = await fetch('/api/auth/passkey/register/begin', {method:'POST'});
+    const beginData = await begin.json();
+    if(!begin.ok){ alert(beginData.error||'Passkey registration failed'); return; }
+    const credential = await SimpleWebAuthnBrowser.startRegistration(beginData.options);
+    const finish = await fetch('/api/auth/passkey/register/finish', {
+      method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(credential)
+    });
+    const finishData = await finish.json();
+    if(finish.ok && finishData.ok){ alert('Passkey registered successfully'); return; }
+    alert(finishData.error || 'Passkey registration failed');
+  }catch(e){ alert('Passkey registration cancelled or unsupported.'); }
+}
 </script>
 <!-- Graph Fullscreen Overlay -->
 <div id="graph-fs-overlay" onclick="if(event.target===this)closeGraphFs()">

--- a/templates/login.html
+++ b/templates/login.html
@@ -70,10 +70,34 @@
       </label>
 
       <button type="submit">Login</button>
+      <button type="button" id="passkeyLoginBtn">Login with passkey</button>
 
       {% if error %}<div class="error">{{ error }}</div>{% endif %}
     </form>
     <div class="footer">Meshtastic AI Bridge &bull; LAN Panel</div>
   </div>
+  <script>
+    async function passkeyLogin() {
+      const username = document.getElementById('username').value || "{{ username }}";
+      const begin = await fetch('/api/auth/passkey/login/begin', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({username})
+      });
+      const beginData = await begin.json();
+      if (!begin.ok) { alert(beginData.error || 'Passkey login failed'); return; }
+      const credential = await SimpleWebAuthnBrowser.startAuthentication(beginData.options);
+      const finish = await fetch('/api/auth/passkey/login/finish', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(credential)
+      });
+      const finishData = await finish.json();
+      if (finish.ok && finishData.ok) { window.location.href = finishData.redirect || '/'; return; }
+      alert(finishData.error || 'Passkey verification failed');
+    }
+    document.getElementById('passkeyLoginBtn').addEventListener('click', passkeyLogin);
+  </script>
+  <script src="https://unpkg.com/@simplewebauthn/browser/dist/bundle/index.umd.min.js"></script>
 </body>
 </html>

--- a/test_web_ui_passkey.py
+++ b/test_web_ui_passkey.py
@@ -1,0 +1,32 @@
+import os
+import importlib
+import pytest
+
+
+def _load_app(tmp_path):
+    os.environ['WEB_UI_PASSWORD'] = 'secret'
+    os.environ['WEB_UI_USERNAME'] = 'admin'
+    os.environ['WEB_UI_SECRET_KEY'] = 'test-secret-key'
+    os.environ['WEB_UI_WEBAUTHN_RP_ID'] = 'localhost'
+    os.environ['WEB_UI_WEBAUTHN_ORIGIN'] = 'http://localhost:8080'
+    mod = importlib.import_module('web_ui')
+    if not hasattr(mod, 'app'):
+        pytest.skip('Flask/webauthn dependencies are not installed in this environment')
+    mod._WEBAUTHN_CREDENTIALS_PATH = str(tmp_path / 'webauthn_credentials.json')
+    mod.app.config['TESTING'] = True
+    return mod.app
+
+
+def test_passkey_login_begin_requires_configured_passkey(tmp_path):
+    app = _load_app(tmp_path)
+    c = app.test_client()
+    r = c.post('/api/auth/passkey/login/begin', json={'username': 'admin'})
+    assert r.status_code in (400, 501)
+    assert r.get_json()['ok'] is False
+
+
+def test_passkey_registration_requires_auth(tmp_path):
+    app = _load_app(tmp_path)
+    c = app.test_client()
+    r = c.post('/api/auth/passkey/register/begin')
+    assert r.status_code in (301, 302)

--- a/web_ui.py
+++ b/web_ui.py
@@ -16,6 +16,7 @@ Environment variables:
 """
 
 import json
+import base64
 import logging
 import os
 import threading
@@ -42,6 +43,25 @@ except ImportError:
     _HAS_FLASK = False
     logger.warning("web_ui: Flask not installed — web interface disabled")
 
+try:
+    from webauthn import (
+        generate_registration_options,
+        verify_registration_response,
+        generate_authentication_options,
+        verify_authentication_response,
+    )
+    from webauthn.helpers.structs import (
+        AuthenticatorSelectionCriteria,
+        PublicKeyCredentialDescriptor,
+        RegistrationCredential,
+        AuthenticationCredential,
+        ResidentKeyRequirement,
+        UserVerificationRequirement,
+    )
+    _HAS_WEBAUTHN = True
+except ImportError:
+    _HAS_WEBAUTHN = False
+
 
 # ---------------------------------------------------------------------------
 # Shared state
@@ -51,7 +71,38 @@ _messages: deque = deque(maxlen=500)
 _packets:  deque = deque(maxlen=1000)
 
 _CHAT_HISTORY_PATH = os.path.join("data", "chat_history.json")
+_WEBAUTHN_CREDENTIALS_PATH = os.path.join("data", "webauthn_credentials.json")
 _save_pending = False
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("utf-8")
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = "=" * ((4 - len(data) % 4) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def _load_webauthn_credentials() -> list[dict]:
+    if not os.path.exists(_WEBAUTHN_CREDENTIALS_PATH):
+        return []
+    try:
+        with open(_WEBAUTHN_CREDENTIALS_PATH, "r", encoding="utf-8") as f:
+            creds = json.load(f)
+        return creds if isinstance(creds, list) else []
+    except Exception as e:
+        logger.warning(f"webauthn: could not load credentials: {e}")
+        return []
+
+
+def _save_webauthn_credentials(creds: list[dict]) -> None:
+    try:
+        os.makedirs(os.path.dirname(_WEBAUTHN_CREDENTIALS_PATH), exist_ok=True)
+        with open(_WEBAUTHN_CREDENTIALS_PATH, "w", encoding="utf-8") as f:
+            json.dump(creds, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        logger.warning(f"webauthn: could not save credentials: {e}")
 
 
 def _load_chat_history() -> None:
@@ -630,6 +681,9 @@ if _HAS_FLASK:
 
     WEB_UI_PASSWORD = os.environ.get("WEB_UI_PASSWORD", "")
     WEB_UI_USERNAME = os.environ.get("WEB_UI_USERNAME", "admin")
+    WEB_UI_RP_ID = os.environ.get("WEB_UI_WEBAUTHN_RP_ID", "localhost")
+    WEB_UI_RP_NAME = os.environ.get("WEB_UI_WEBAUTHN_RP_NAME", "Meshtastic AI Bridge")
+    WEB_UI_ORIGIN = os.environ.get("WEB_UI_WEBAUTHN_ORIGIN", f"http://{WEB_UI_RP_ID}:8080")
 
     # ------------------------------------------------------------------
     # Auth
@@ -655,7 +709,109 @@ if _HAS_FLASK:
                 session["logged_in"] = True
                 return redirect(url_for("index"))
             error = "Invalid credentials"
-        return render_template("login.html", error=error)
+        return render_template("login.html", error=error, username=WEB_UI_USERNAME)
+
+    @app.route("/api/auth/passkey/register/begin", methods=["POST"])
+    @login_required
+    def passkey_register_begin():
+        if not _HAS_WEBAUTHN:
+            return jsonify({"ok": False, "error": "WebAuthn backend not installed"}), 501
+        user_handle = WEB_UI_USERNAME.encode("utf-8")
+        creds = _load_webauthn_credentials()
+        exclude_creds = [PublicKeyCredentialDescriptor(id=_b64url_decode(c["credential_id"])) for c in creds]
+        options = generate_registration_options(
+            rp_id=WEB_UI_RP_ID,
+            rp_name=WEB_UI_RP_NAME,
+            user_id=user_handle,
+            user_name=WEB_UI_USERNAME,
+            authenticator_selection=AuthenticatorSelectionCriteria(
+                resident_key=ResidentKeyRequirement.PREFERRED,
+                user_verification=UserVerificationRequirement.PREFERRED,
+            ),
+            exclude_credentials=exclude_creds,
+        )
+        session["webauthn_registration_challenge"] = _b64url_encode(options.challenge)
+        return jsonify({"ok": True, "options": options.model_dump()})
+
+    @app.route("/api/auth/passkey/register/finish", methods=["POST"])
+    @login_required
+    def passkey_register_finish():
+        if not _HAS_WEBAUTHN:
+            return jsonify({"ok": False, "error": "WebAuthn backend not installed"}), 501
+        payload = request.get_json(silent=True) or {}
+        challenge = session.get("webauthn_registration_challenge")
+        if not challenge:
+            return jsonify({"ok": False, "error": "Missing registration challenge"}), 400
+        try:
+            verification = verify_registration_response(
+                credential=RegistrationCredential.parse_obj(payload),
+                expected_challenge=_b64url_decode(challenge),
+                expected_rp_id=WEB_UI_RP_ID,
+                expected_origin=WEB_UI_ORIGIN,
+            )
+            creds = _load_webauthn_credentials()
+            creds.append({
+                "credential_id": _b64url_encode(verification.credential_id),
+                "public_key": _b64url_encode(verification.credential_public_key),
+                "sign_count": verification.sign_count,
+                "transports": payload.get("response", {}).get("transports", []),
+            })
+            _save_webauthn_credentials(creds)
+            session.pop("webauthn_registration_challenge", None)
+            return jsonify({"ok": True})
+        except Exception as e:
+            return jsonify({"ok": False, "error": str(e)}), 400
+
+    @app.route("/api/auth/passkey/login/begin", methods=["POST"])
+    def passkey_login_begin():
+        if not _HAS_WEBAUTHN:
+            return jsonify({"ok": False, "error": "WebAuthn backend not installed"}), 501
+        payload = request.get_json(silent=True) or {}
+        username = payload.get("username", WEB_UI_USERNAME)
+        if username != WEB_UI_USERNAME:
+            return jsonify({"ok": False, "error": "Invalid credentials"}), 401
+        creds = _load_webauthn_credentials()
+        if not creds:
+            return jsonify({"ok": False, "error": "Passkey not configured"}), 400
+        allow_creds = [PublicKeyCredentialDescriptor(id=_b64url_decode(c["credential_id"])) for c in creds]
+        options = generate_authentication_options(
+            rp_id=WEB_UI_RP_ID,
+            allow_credentials=allow_creds,
+            user_verification=UserVerificationRequirement.PREFERRED,
+        )
+        session["webauthn_auth_challenge"] = _b64url_encode(options.challenge)
+        return jsonify({"ok": True, "options": options.model_dump()})
+
+    @app.route("/api/auth/passkey/login/finish", methods=["POST"])
+    def passkey_login_finish():
+        if not _HAS_WEBAUTHN:
+            return jsonify({"ok": False, "error": "WebAuthn backend not installed"}), 501
+        payload = request.get_json(silent=True) or {}
+        challenge = session.get("webauthn_auth_challenge")
+        if not challenge:
+            return jsonify({"ok": False, "error": "Missing authentication challenge"}), 400
+        creds = _load_webauthn_credentials()
+        cred_id = payload.get("id")
+        match = next((c for c in creds if c["credential_id"] == cred_id), None)
+        if not match:
+            return jsonify({"ok": False, "error": "Invalid credentials"}), 401
+        try:
+            verification = verify_authentication_response(
+                credential=AuthenticationCredential.parse_obj(payload),
+                expected_challenge=_b64url_decode(challenge),
+                expected_rp_id=WEB_UI_RP_ID,
+                expected_origin=WEB_UI_ORIGIN,
+                credential_public_key=_b64url_decode(match["public_key"]),
+                credential_current_sign_count=int(match.get("sign_count", 0)),
+            )
+            match["sign_count"] = verification.new_sign_count
+            _save_webauthn_credentials(creds)
+            session.pop("webauthn_auth_challenge", None)
+            session["logged_in"] = True
+            session.permanent = True
+            return jsonify({"ok": True, "redirect": url_for("index")})
+        except Exception as e:
+            return jsonify({"ok": False, "error": str(e)}), 401
 
     @app.route("/logout")
     def logout():


### PR DESCRIPTION
### Motivation

- Provide a safer, fallback-resistant authentication option for the Web UI by adding WebAuthn/passkey support alongside existing username/password login.
- Persist registered passkeys so LAN deployments can use browser-based passkeys without relying solely on passwords.
- Expose basic configuration via environment variables to make origin and RP settings configurable for local and LAN deployments.

### Description

- Add WebAuthn backend integration in `web_ui.py`, including helper functions for base64url encoding/decoding, loading/saving credentials to `data/webauthn_credentials.json`, and routes for registration and authentication flows (`/api/auth/passkey/register/begin`, `/api/auth/passkey/register/finish`, `/api/auth/passkey/login/begin`, `/api/auth/passkey/login/finish`).
- Add environment variables `WEB_UI_WEBAUTHN_RP_ID`, `WEB_UI_WEBAUTHN_RP_NAME`, and `WEB_UI_WEBAUTHN_ORIGIN` for RP and origin configuration and use them when generating/verifying WebAuthn options.
- Update templates to surface passkey UI: add a "Register passkey" button in `templates/index.html`, include the `@simplewebauthn/browser` client script and `registerPasskey()` handler, and add a "Login with passkey" button and client-side flow in `templates/login.html`.
- Update `requirements.txt` to include `webauthn>=2.1.0` and add documentation in `docs/CONFIGURATION.md` describing WebAuthn environment variables, deployment notes, and storage location for passkeys.
- Add unit tests in `test_web_ui_passkey.py` that exercise basic passkey registration/login endpoints and handle missing dependencies gracefully.

### Testing

- Ran the new unit tests with `pytest -q test_web_ui_passkey.py` and they completed successfully (tests skip when Flask/webauthn are not installed in the environment). 
- The passkey endpoints were exercised in tests for expected error/redirect responses and returned the anticipated status codes when prerequisites are missing or authentication is incomplete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a4cba598832bb1423399d6063c30)